### PR TITLE
Nomalized Name Collisons

### DIFF
--- a/api/src/app/core/cdktf/ranges/base_range.py
+++ b/api/src/app/core/cdktf/ranges/base_range.py
@@ -32,15 +32,6 @@ logger = logging.getLogger(__name__)
 class AbstractBaseRange(ABC):
     """Abstract class to enforce common functionality across range cloud providers."""
 
-    name: str
-    range_obj: BlueprintRangeSchema | DeployedRangeSchema
-    state_file: dict[str, Any] | None  # Terraform state
-    region: OpenLabsRegion
-    stack_name: str
-    secrets: SecretSchema
-    deployed_range_name: str
-    description: str
-
     # Mutex for terraform init calls
     _init_lock = asyncio.Lock()
 

--- a/api/src/app/core/cdktf/stacks/aws_stack.py
+++ b/api/src/app/core/cdktf/stacks/aws_stack.py
@@ -22,8 +22,8 @@ from ....enums.operating_systems import AWS_OS_MAP
 from ....enums.regions import AWS_REGION_MAP, OpenLabsRegion
 from ....enums.specs import AWS_SPEC_MAP
 from ....schemas.range_schemas import BlueprintRangeSchema, DeployedRangeSchema
+from ....utils.cdktf_utils import gen_resource_logical_ids
 from ....utils.crypto import generate_range_rsa_key_pair
-from ....utils.name_utils import normalize_name
 from .base_stack import AbstractBaseStack
 
 
@@ -267,23 +267,23 @@ class AWSStack(AbstractBaseStack):
         )
 
         # Create Range vpcs, subnets, hosts
+        vpc_logical_ids = gen_resource_logical_ids([vpc.name for vpc in range_obj.vpcs])
         for vpc in range_obj.vpcs:
-
-            normalized_vpc_name = normalize_name(vpc.name)
+            vpc_logical_id = vpc_logical_ids[vpc.name]
 
             # Step 14: Create a VPC
             new_vpc = Vpc(
                 self,
-                f"{range_name}-{normalized_vpc_name}",
+                f"{range_name}-{vpc_logical_id}",
                 cidr_block=str(vpc.cidr),
                 enable_dns_support=True,
                 enable_dns_hostnames=True,
-                tags={"Name": normalized_vpc_name},
+                tags={"Name": vpc_logical_id},
             )
 
             TerraformOutput(
                 self,
-                f"{range_name}-{normalized_vpc_name}-resource-id",
+                f"{range_name}-{vpc_logical_id}-resource-id",
                 value=new_vpc.id,
                 description="Cloud resource id of the vpc created",
                 sensitive=True,
@@ -294,13 +294,13 @@ class AWSStack(AbstractBaseStack):
             # Every VPC will use the same secrutiy group but security groups are scoped to a single VPC, so they have to be added to each one
             private_vpc_sg = SecurityGroup(
                 self,
-                f"{range_name}-{normalized_vpc_name}-SharedPrivateSG",
+                f"{range_name}-{vpc_logical_id}-SharedPrivateSG",
                 vpc_id=new_vpc.id,
                 tags={"Name": "RangePrivateInternalSecurityGroup"},
             )
             SecurityGroupRule(  # Allow access from the Jumpbox - possibly not needed based on next rule
                 self,
-                f"{range_name}-{normalized_vpc_name}-RangeAllowAllTrafficFromJumpBox-Rule",
+                f"{range_name}-{vpc_logical_id}-RangeAllowAllTrafficFromJumpBox-Rule",
                 type="ingress",
                 from_port=0,
                 to_port=0,
@@ -310,7 +310,7 @@ class AWSStack(AbstractBaseStack):
             )
             SecurityGroupRule(
                 self,
-                f"{range_name}-{normalized_vpc_name}-RangeAllowInternalTraffic-Rule",  # Allow all internal subnets to communicate with each other
+                f"{range_name}-{vpc_logical_id}-RangeAllowInternalTraffic-Rule",  # Allow all internal subnets to communicate with each other
                 type="ingress",
                 from_port=0,
                 to_port=0,
@@ -320,7 +320,7 @@ class AWSStack(AbstractBaseStack):
             )
             SecurityGroupRule(
                 self,
-                f"{range_name}-{normalized_vpc_name}-RangeAllowPrivateOutbound-Rule",
+                f"{range_name}-{vpc_logical_id}-RangeAllowPrivateOutbound-Rule",
                 type="egress",
                 from_port=0,
                 to_port=0,
@@ -330,23 +330,25 @@ class AWSStack(AbstractBaseStack):
             )
 
             current_vpc_subnets: list[Subnet] = []
+            subnet_logical_ids = gen_resource_logical_ids(
+                [subnet.name for subnet in vpc.subnets]
+            )
             # Step 16: Create private subnets with their respecitve EC2 instances
             for subnet in vpc.subnets:
-
-                normalized_subnet_name = normalize_name(subnet.name)
+                subnet_logical_id = subnet_logical_ids[subnet.name]
 
                 new_subnet = Subnet(
                     self,
-                    f"{range_name}-{normalized_vpc_name}-{normalized_subnet_name}",
+                    f"{range_name}-{vpc_logical_id}-{subnet_logical_id}",
                     vpc_id=new_vpc.id,
                     cidr_block=str(subnet.cidr),
                     availability_zone="us-east-1a",
-                    tags={"Name": normalized_subnet_name},
+                    tags={"Name": subnet_logical_id},
                 )
 
                 TerraformOutput(
                     self,
-                    f"{range_name}-{normalized_vpc_name}-{normalized_subnet_name}-resource-id",
+                    f"{range_name}-{vpc_logical_id}-{subnet_logical_id}-resource-id",
                     value=new_subnet.id,
                     description="Cloud resource id of the subnet created",
                     sensitive=True,
@@ -358,7 +360,7 @@ class AWSStack(AbstractBaseStack):
                 for host in subnet.hosts:
                     ec2_instance = Instance(
                         self,
-                        f"{range_name}-{normalized_vpc_name}-{normalized_subnet_name}-{host.hostname}",
+                        f"{range_name}-{vpc_logical_id}-{subnet_logical_id}-{host.hostname}",
                         ami=AWS_OS_MAP[host.os],
                         instance_type=AWS_SPEC_MAP[host.spec],
                         subnet_id=new_subnet.id,
@@ -369,14 +371,14 @@ class AWSStack(AbstractBaseStack):
 
                     TerraformOutput(
                         self,
-                        f"{range_name}-{normalized_vpc_name}-{normalized_subnet_name}-{host.hostname}-resource-id",
+                        f"{range_name}-{vpc_logical_id}-{subnet_logical_id}-{host.hostname}-resource-id",
                         value=ec2_instance.id,
                         description="Cloud resource id of the ec2 instance created",
                         sensitive=True,
                     )
                     TerraformOutput(
                         self,
-                        f"{range_name}-{normalized_vpc_name}-{normalized_subnet_name}-{host.hostname}-private-ip",
+                        f"{range_name}-{vpc_logical_id}-{subnet_logical_id}-{host.hostname}-private-ip",
                         value=ec2_instance.private_ip,
                         description="Cloud private IP address of the ec2 instance created",
                         sensitive=True,
@@ -385,7 +387,7 @@ class AWSStack(AbstractBaseStack):
             # Step 17: Attach  VPC to Transit Gateway
             private_vpc_tgw_attachment = Ec2TransitGatewayVpcAttachment(  # noqa: F841
                 self,
-                f"{range_name}-{normalized_vpc_name}-PrivateVpcTgwAttachment",
+                f"{range_name}-{vpc_logical_id}-PrivateVpcTgwAttachment",
                 subnet_ids=[
                     current_vpc_subnets[0].id
                 ],  # Attach TGW ENIs to all private subnets
@@ -393,20 +395,20 @@ class AWSStack(AbstractBaseStack):
                 vpc_id=new_vpc.id,
                 transit_gateway_default_route_table_association=True,
                 transit_gateway_default_route_table_propagation=True,
-                tags={"Name": f"{normalized_vpc_name}-private-vpc-tgw-attachment"},
+                tags={"Name": f"{vpc_logical_id}-private-vpc-tgw-attachment"},
             )
 
             # Step 18: Create Routing in range VPC (Routes to TGW to access other range VPCs or the internet via the NAT gateway)
             new_vpc_private_route_table = RouteTable(
                 self,
-                f"{range_name}-{normalized_vpc_name}-PrivateRouteTable",
+                f"{range_name}-{vpc_logical_id}-PrivateRouteTable",
                 vpc_id=new_vpc.id,
-                tags={"Name": f"{normalized_vpc_name}-private-route-table"},
+                tags={"Name": f"{vpc_logical_id}-private-route-table"},
             )
             # Default route for range VPC to Transit Gateway
             tgw_route = Route(  # noqa: F841
                 self,
-                f"{range_name}-{normalized_vpc_name}-PrivateTgwRoute",
+                f"{range_name}-{vpc_logical_id}-PrivateTgwRoute",
                 route_table_id=new_vpc_private_route_table.id,
                 destination_cidr_block="0.0.0.0/0",  # All traffic goes to TGW
                 transit_gateway_id=tgw.id,
@@ -415,7 +417,7 @@ class AWSStack(AbstractBaseStack):
             for i, created_subnet in enumerate(current_vpc_subnets):
                 RouteTableAssociation(
                     self,
-                    f"{range_name}-{normalized_vpc_name}-PrivateSubnetRouteTableAssociation_{i+1}",
+                    f"{range_name}-{vpc_logical_id}-PrivateSubnetRouteTableAssociation_{i+1}",
                     subnet_id=str(created_subnet.id),
                     route_table_id=new_vpc_private_route_table.id,
                 )
@@ -425,7 +427,7 @@ class AWSStack(AbstractBaseStack):
             # Add route to the Jumpbox VPC's Public route table (for Jumpbox access & NAT Return Traffic)
             Route(
                 self,
-                f"{range_name}-{normalized_vpc_name}-PublicRtbToPrivateVpcRoute",
+                f"{range_name}-{vpc_logical_id}-PublicRtbToPrivateVpcRoute",
                 route_table_id=jumpbox_route_table.id,  # Route in the public subnet's RT
                 destination_cidr_block=new_vpc.cidr_block,  # Traffic destined to the range VPCs will go through the transit gateway
                 transit_gateway_id=tgw.id,
@@ -434,7 +436,7 @@ class AWSStack(AbstractBaseStack):
             # This ensures traffic arriving *from* the TGW destined for another private VPC goes back *to* the TGW
             Route(
                 self,
-                f"{range_name}-{normalized_vpc_name}-PublicVpcTgwSubnetRtbToPrivateVpcRoute",
+                f"{range_name}-{vpc_logical_id}-PublicVpcTgwSubnetRtbToPrivateVpcRoute",
                 route_table_id=nat_route_table.id,  # Route in the TGW attachment subnet's Route Table (jumpbox private subnet)
                 destination_cidr_block=new_vpc.cidr_block,  # Traffic destined to the range VPCs will go through the transit gateway
                 transit_gateway_id=tgw.id,

--- a/api/src/app/utils/cdktf_utils.py
+++ b/api/src/app/utils/cdktf_utils.py
@@ -1,7 +1,63 @@
 import tempfile
+from collections import Counter, defaultdict
+
+from .name_utils import normalize_name
 
 
 def create_cdktf_dir() -> str:
     """Create temp dir for CDKTF."""
     # /tmp/.openlabs-cdktf-XXXX
     return tempfile.mkdtemp(prefix=".openlabs-cdktf-")
+
+
+def gen_resource_logical_ids(resource_names: list[str]) -> dict[str, str]:
+    """Generate deterministic, normalized, and unique logical IDs from a list of resource names.
+
+    This function handles collisions that occur after normalization by appending
+    a numeric suffix.
+
+    Args:
+        resource_names: A list of user-supplied resource names.
+
+    Returns:
+        A dictionary mapping each original resource name to its unique logical ID.
+
+    Example:
+        >>> names = ["Web Server", "Database", "web-server", "Auth Service"]
+        >>> gen_resource_logical_ids(names)
+        {
+            'Auth Service': 'auth-service',
+            'Database': 'database',
+            'Web Server': 'web-server',
+            'web-server': 'web-server-1'
+        }
+
+    """
+    if len(set(resource_names)) != len(resource_names):
+        counts = Counter(resource_names)
+        duplicates = [name for name, count in counts.items() if count > 1]
+        msg = f"Input list contains duplicate names: {', '.join(duplicates)}"
+        raise ValueError(msg)
+
+    logical_ids: dict[str, str] = {}
+    seen_counts: defaultdict[str, int] = defaultdict(int)
+
+    # Sorted to ensure deterministic ID generation
+    sorted_names = sorted(resource_names)
+
+    for name in sorted_names:
+        base_id = normalize_name(name)
+
+        # The first time we see a base_id, its ID is just itself
+        # each time we see it again we add a suffix
+        if seen_counts[base_id] > 0:
+            logical_id = f"{base_id}-{seen_counts[base_id]}"
+        else:
+            logical_id = base_id
+
+        logical_ids[name] = logical_id
+
+        # Increment the count for the next potential collision
+        seen_counts[base_id] += 1
+
+    return logical_ids

--- a/api/src/app/utils/name_utils.py
+++ b/api/src/app/utils/name_utils.py
@@ -1,3 +1,27 @@
+import re
+
+
 def normalize_name(name: str) -> str:
-    """Remove problematic characters from user-supplied names."""
-    return name.strip().replace(" ", "")
+    """Remove problematic characters from user-supplied names for cloud deployments while maintaining readability.
+
+    Args:
+        name: Name to normalize.
+
+    Returns:
+        Name normalized to a safe kebab case version.
+
+    """
+    normalized_name = name.lower()
+
+    # Strip out disallowed characters
+    normalized_name = re.sub(r"[^a-z0-9\-]", "-", normalized_name)
+
+    # Remove extra hyphens
+    normalized_name = re.sub(r"-+", "-", normalized_name)
+    normalized_name = normalized_name.strip("-")
+
+    if not normalized_name:
+        msg = f"Name is empty after normalization. Original name: '{name}'"
+        raise ValueError(msg)
+
+    return normalized_name

--- a/api/tests/common/api/v1/config.py
+++ b/api/tests/common/api/v1/config.py
@@ -130,6 +130,21 @@ valid_blueprint_range_multi_create_payload: dict[str, Any] = {
                         }
                     ],
                 },
+                # This is here to test that we handle
+                # normalized name collisions
+                {
+                    "cidr": "10.0.3.0/24",
+                    "name": "dev_subnet_app",
+                    "hosts": [
+                        {
+                            "hostname": "dev-app-01",
+                            "os": "debian_11",
+                            "spec": "medium",
+                            "size": 30,
+                            "tags": ["app", "linux"],
+                        }
+                    ],
+                },
             ],
         },
         {

--- a/api/tests/common/api/v1/config.py
+++ b/api/tests/common/api/v1/config.py
@@ -139,7 +139,7 @@ valid_blueprint_range_multi_create_payload: dict[str, Any] = {
                         {
                             "hostname": "dev-app-01",
                             "os": "debian_11",
-                            "spec": "medium",
+                            "spec": "small",
                             "size": 30,
                             "tags": ["app", "linux"],
                         }

--- a/api/tests/unit/utils/test_cdktf_utils.py
+++ b/api/tests/unit/utils/test_cdktf_utils.py
@@ -1,0 +1,86 @@
+import pytest
+
+from src.app.utils.cdktf_utils import gen_resource_logical_ids
+
+
+@pytest.mark.parametrize(
+    "input_names, expected_ids",
+    [
+        # Basic cases
+        pytest.param([], {}, id="empty_list"),
+        pytest.param(["MyServer"], {"MyServer": "myserver"}, id="single_name"),
+        pytest.param(
+            ["Server1", "Server2"],
+            {"Server1": "server1", "Server2": "server2"},
+            id="two_unique_names",
+        ),
+        pytest.param(
+            ["Web Server", "Database", "Auth Service"],
+            {
+                "Auth Service": "auth-service",
+                "Database": "database",
+                "Web Server": "web-server",
+            },
+            id="multiple_unique_names_with_spaces",
+        ),
+        # Collision handling
+        pytest.param(
+            ["Web Server", "web-server"],
+            {"Web Server": "web-server", "web-server": "web-server-1"},
+            id="two_collide_after_norm",
+        ),
+        pytest.param(
+            ["Server", "server", "sErVeR"],
+            {"Server": "server", "sErVeR": "server-1", "server": "server-2"},
+            id="three_collide_after_norm",
+        ),
+        pytest.param(
+            ["App-Service", "App Service", "app_service"],
+            {
+                "App Service": "app-service",
+                "App-Service": "app-service-1",
+                "app_service": "app-service-2",
+            },
+            id="multiple_collision_types",
+        ),
+        # Sorted order affects suffix assignment
+        pytest.param(
+            ["A", "a", "A-", "-a"],
+            {"A": "a-1", "-a": "a", "A-": "a-2", "a": "a-3"},
+            id="complex_collision_leading_trailing_symbols",
+        ),
+        # Names that normalize to the same base but are distinct in input
+        pytest.param(
+            ["user-profile", "User Profile"],
+            {"user-profile": "user-profile-1", "User Profile": "user-profile"},
+            id="distinct_input_same_norm",
+        ),
+        pytest.param(
+            ["my_app", "my-app"],
+            {"my_app": "my-app-1", "my-app": "my-app"},
+            id="underscore_vs_hyphen",
+        ),
+    ],
+)
+def test_gen_resource_logical_ids_success(
+    input_names: list[str], expected_ids: dict[str, str]
+) -> None:
+    """Test various valid inputs for gen_resource_logical_ids to validate ID generation and collision handling."""
+    result = gen_resource_logical_ids(input_names)
+    assert result == expected_ids
+
+
+@pytest.mark.parametrize(
+    "input_names",
+    [
+        pytest.param(["Duplicate", "Duplicate"], id="exact_duplicate_names"),
+        pytest.param(["Test", "test", "Test"], id="exact_duplicate_mixed_case"),
+        pytest.param(["A", "B", "A", "C", "B"], id="multiple_exact_duplicates"),
+    ],
+)
+def test_gen_resource_logical_ids_duplicate_error(
+    input_names: list[str],
+) -> None:
+    """Tests that gen_resource_logical_ids raises a ValueError when the input list contains exact duplicate names."""
+    with pytest.raises(ValueError, match="duplicate"):
+        gen_resource_logical_ids(input_names)

--- a/api/tests/unit/utils/test_name_utils.py
+++ b/api/tests/unit/utils/test_name_utils.py
@@ -1,0 +1,79 @@
+import pytest
+
+from src.app.utils.name_utils import normalize_name
+
+
+@pytest.mark.parametrize(
+    "input_name, expected_output",
+    [
+        # Basic cases
+        ("My Awesome Lab", "my-awesome-lab"),
+        ("another_test_name", "another-test-name"),
+        ("simple-name", "simple-name"),  # Already normalized
+        ("TestName", "testname"),  # Mixed case
+        ("test123name", "test123name"),  # Numbers
+        ("test-123-name", "test-123-name"),  # Numbers with hyphens
+        # Special characters
+        (
+            "Name!@#$%^&*()_+={}|[]\\:;\"'<>,.?/~`",
+            "name",
+        ),
+        ("Name with.dots", "name-with-dots"),
+        ("Name with/slashes", "name-with-slashes"),
+        ("Name with spaces and -hyphens", "name-with-spaces-and-hyphens"),
+        # Multiple consecutive problematic characters
+        ("Name--with---multiple____hyphens", "name-with-multiple-hyphens"),
+        ("Name   with   many   spaces", "name-with-many-spaces"),
+        ("Name_-_With_Mixed_Separators", "name-with-mixed-separators"),
+        ("a---b", "a-b"),
+        ("a___b", "a-b"),
+        ("a...b", "a-b"),
+        ("a@@@b", "a-b"),
+        # Leading/trailing problematic characters
+        ("-Name-Starts-With-Hyphen", "name-starts-with-hyphen"),
+        ("Name-Ends-With-Hyphen-", "name-ends-with-hyphen"),
+        (
+            "  Name With Leading And Trailing Spaces  ",
+            "name-with-leading-and-trailing-spaces",
+        ),
+        ("!@#NameWithSymbols!@#", "namewithsymbols"),
+        ("---Name---", "name"),
+        ("___Name___", "name"),
+        ("...Name...", "name"),
+        # Names that are already clean
+        ("already-kebab-case", "already-kebab-case"),
+        ("lowercasealphanumeric", "lowercasealphanumeric"),
+    ],
+)
+def test_normalize_name_valid_cases(input_name: str, expected_output: str) -> None:
+    """Test various valid input names to ensure they are normalized correctly to safe kebab-case versions."""
+    assert normalize_name(input_name) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_name",
+    [
+        "",  # Empty string
+        "   ",  # Only spaces
+        "---",  # Only hyphens
+        "!!!",  # Only special characters
+        " @#$ ",  # Mixed problematic characters
+        " _ ",  # Only underscores
+        " . ",  # Only dots
+    ],
+    ids=[
+        "empty_string",
+        "only_spaces",
+        "only_hyphens",
+        "only_special_chars",
+        "mixed_problematic_chars",
+        "only_underscores",
+        "only_dots",
+    ],
+)
+def test_normalize_name_empty_raises_value_error(
+    input_name: str,
+) -> None:
+    """Test input names that should result in an empty string after normalization that force a ValueError to be raised."""
+    with pytest.raises(ValueError, match="empty"):
+        normalize_name(input_name)


### PR DESCRIPTION
## Checklist

- [ ] I have added a version label to my PR (e.g., patch, minor, major).
- [ ] I have tested my changes locally and verified they work as expected.
- [ ] I have added relevant tests to cover my changes.
- [ ] I have made any necessary updates to the documentation.
- [ ] I have made any necessary updates to the CLI.
- [ ] I have made any necessary updates to the frontend.

## Description

This PR builds on the solution in PR https://github.com/OpenLabsHQ/OpenLabs/pull/139 by creating a function that generates unique logical ids for resources by normalizing them (like before) and then appending suffixes to prevent name collisions. For example, the names `My Subnet` and `my subnet` --> `my-subnet` and `my-subnet-1` which would collide before.

Additionally, this PR improves the normalization function to create kebab case names for better readability and cross cloud compatibility.

Fixes known issue 1 in: https://github.com/OpenLabsHQ/OpenLabs/pull/139
