### PR TITLE
Simplify Lab Schema Validation

### DIFF
--- a/api/src/app/schemas/vpc_schemas.py
+++ b/api/src/app/schemas/vpc_schemas.py
@@ -1,6 +1,13 @@
 from ipaddress import IPv4Network
+from typing import Self, Sequence
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from ..validators.names import OPENLABS_NAME_REGEX
 from ..validators.network import all_subnets_contained, mutually_exclusive_networks_v4
@@ -9,6 +16,7 @@ from .subnet_schemas import (
     BlueprintSubnetSchema,
     DeployedSubnetCreateSchema,
     DeployedSubnetSchema,
+    SubnetCommonSchema,
 )
 
 
@@ -26,21 +34,13 @@ class VPCCommonSchema(BaseModel):
     )
 
 
-# ==================== Blueprints =====================
+class VPCCreateValidationMixin(BaseModel):
+    """Mixin class with common validation for all VPC creation schemas."""
 
-
-class BlueprintVPCBaseSchema(VPCCommonSchema):
-    """Base pydantic class for all blueprint VPC objects."""
-
-    pass
-
-
-class BlueprintVPCCreateSchema(BlueprintVPCBaseSchema):
-    """Schema to create blueprint VPC objects."""
-
-    subnets: list[BlueprintSubnetCreateSchema] = Field(
-        ..., description="All blueprint subnets in VPC."
-    )
+    # Forward references
+    name: str
+    cidr: IPv4Network
+    subnets: Sequence[SubnetCommonSchema]
 
     @field_validator("cidr")
     @classmethod
@@ -51,68 +51,55 @@ class BlueprintVPCCreateSchema(BlueprintVPCBaseSchema):
             raise ValueError(msg)
         return cidr
 
-    @field_validator("subnets")
-    @classmethod
-    def validate_unique_subnet_names(
-        cls, subnets: list[BlueprintSubnetCreateSchema], info: ValidationInfo
-    ) -> list[BlueprintSubnetCreateSchema]:
+    @model_validator(mode="after")
+    def validate_unique_subnet_names(self) -> Self:
         """Check subnet names are unique."""
-        subnet_names = [subnet.name for subnet in subnets]
+        if not self.subnets:
+            return self
 
+        subnet_names = [subnet.name for subnet in self.subnets]
         if len(subnet_names) != len(set(subnet_names)):
-            vpc_name = info.data.get("name")
-            if not vpc_name:
-                msg = "VPC is missing a name."
-                raise ValueError(msg)
-
-            msg = f"All subnet in VPC: {vpc_name} must have unique names."
+            msg = f"All subnet in VPC: {self.name} must have unique names."
             raise ValueError(msg)
 
-        return subnets
+        return self
 
-    @field_validator("subnets")
-    @classmethod
-    def validate_subnets_contained(
-        cls, subnets: list[BlueprintSubnetCreateSchema], info: ValidationInfo
-    ) -> list[BlueprintSubnetCreateSchema]:
+    @model_validator(mode="after")
+    def validate_subnets_contained(self) -> Self:
         """Check that the VPC CIDR contains all subnet CIDRs."""
-        vpc_name = info.data.get("name")
-        if not vpc_name:
-            msg = "VPC is missing a name."
+        subnet_cidrs = [subnet.cidr for subnet in self.subnets]
+        if not all_subnets_contained(self.cidr, subnet_cidrs):
+            msg = f"All subnets in VPC: {self.name} should be contained within: {self.cidr}"
             raise ValueError(msg)
 
-        vpc_cidr = info.data.get("cidr")
-        if not vpc_cidr:
-            msg = f"VPC: {vpc_name} missing CIDR."
-            raise ValueError(msg)
+        return self
 
-        subnet_cidrs = [subnet.cidr for subnet in subnets]
-        if not all_subnets_contained(vpc_cidr, subnet_cidrs):
-            msg = (
-                f"All subnets in VPC: {vpc_name} should be contained within: {vpc_cidr}"
-            )
-            raise ValueError(msg)
-
-        return subnets
-
-    @field_validator("subnets")
-    @classmethod
-    def validate_mutually_exclusive_subnets(
-        cls, subnets: list[BlueprintSubnetCreateSchema], info: ValidationInfo
-    ) -> list[BlueprintSubnetCreateSchema]:
+    @model_validator(mode="after")
+    def validate_mutually_exclusive_subnets(self) -> Self:
         """Check that subnets do not overlap."""
-        subnet_cidrs = [subnet.cidr for subnet in subnets]
-
+        subnet_cidrs = [subnet.cidr for subnet in self.subnets]
         if not mutually_exclusive_networks_v4(subnet_cidrs):
-            vpc_name = info.data.get("name")
-            if not vpc_name:
-                msg = "VPC is missing a name."
-                raise ValueError(msg)
-
-            msg = f"All subnets in VPC: {vpc_name} should be mutually exclusive (not overlap)."
+            msg = f"All subnets in VPC: {self.name} should be mutually exclusive (not overlap)."
             raise ValueError(msg)
 
-        return subnets
+        return self
+
+
+# ==================== Blueprints =====================
+
+
+class BlueprintVPCBaseSchema(VPCCommonSchema):
+    """Base pydantic class for all blueprint VPC objects."""
+
+    pass
+
+
+class BlueprintVPCCreateSchema(BlueprintVPCBaseSchema, VPCCreateValidationMixin):
+    """Schema to create blueprint VPC objects."""
+
+    subnets: list[BlueprintSubnetCreateSchema] = Field(
+        ..., description="All blueprint subnets in VPC."
+    )
 
 
 class BlueprintVPCSchema(BlueprintVPCBaseSchema):
@@ -148,84 +135,12 @@ class DeployedVPCBaseSchema(VPCCommonSchema):
     )
 
 
-class DeployedVPCCreateSchema(DeployedVPCBaseSchema):
+class DeployedVPCCreateSchema(DeployedVPCBaseSchema, VPCCreateValidationMixin):
     """Schema to create deployed VPC objects."""
 
     subnets: list[DeployedSubnetCreateSchema] = Field(
         ..., description="Deployed subnets within VPC."
     )
-
-    @field_validator("cidr")
-    @classmethod
-    def validate_vpc_private_cidr_range(cls, cidr: IPv4Network) -> IPv4Network:
-        """Check VPC CIDR ranges are private."""
-        if not cidr.is_private:
-            msg = "VPCs should only use private CIDR ranges."
-            raise ValueError(msg)
-        return cidr
-
-    @field_validator("subnets")
-    @classmethod
-    def validate_unique_subnet_names(
-        cls, subnets: list[DeployedSubnetCreateSchema], info: ValidationInfo
-    ) -> list[DeployedSubnetCreateSchema]:
-        """Check subnet names are unique."""
-        subnet_names = [subnet.name for subnet in subnets]
-
-        if len(subnet_names) != len(set(subnet_names)):
-            vpc_name = info.data.get("name")
-            if not vpc_name:
-                msg = "VPC is missing a name."
-                raise ValueError(msg)
-
-            msg = f"All subnet in VPC: {vpc_name} must have unique names."
-            raise ValueError(msg)
-
-        return subnets
-
-    @field_validator("subnets")
-    @classmethod
-    def validate_subnets_contained(
-        cls, subnets: list[DeployedSubnetCreateSchema], info: ValidationInfo
-    ) -> list[DeployedSubnetCreateSchema]:
-        """Check that the VPC CIDR contains all subnet CIDRs."""
-        vpc_name = info.data.get("name")
-        if not vpc_name:
-            msg = "VPC is missing a name."
-            raise ValueError(msg)
-
-        vpc_cidr = info.data.get("cidr")
-        if not vpc_cidr:
-            msg = f"VPC: {vpc_name} missing CIDR."
-            raise ValueError(msg)
-
-        subnet_cidrs = [subnet.cidr for subnet in subnets]
-        if not all_subnets_contained(vpc_cidr, subnet_cidrs):
-            msg = (
-                f"All subnets in VPC: {vpc_name} should be contained within: {vpc_cidr}"
-            )
-            raise ValueError(msg)
-
-        return subnets
-
-    @field_validator("subnets")
-    @classmethod
-    def validate_mutually_exclusive_subnets(
-        cls, subnets: list[DeployedSubnetCreateSchema], info: ValidationInfo
-    ) -> list[DeployedSubnetCreateSchema]:
-        """Check that subnets do not overlap."""
-        subnet_cidrs = [subnet.cidr for subnet in subnets]
-
-        if not mutually_exclusive_networks_v4(subnet_cidrs):
-            vpc_name = info.data.get("name")
-            if not vpc_name:
-                msg = "VPC is missing a name."
-                raise ValueError(msg)
-
-            msg = f"All subnets in VPC: {vpc_name} should be mutually exclusive (not overlap)."
-            raise ValueError(msg)
-
-        return subnets
 
 
 class DeployedVPCSchema(DeployedVPCBaseSchema):


### PR DESCRIPTION
## Checklist

- [x] I have added a version label to my PR (e.g., patch, minor, major).
- [x] I have tested my changes locally and verified they work as expected.
- [x] I have added relevant tests to cover my changes.
- [x] I have made any necessary updates to the documentation.
- [x] I have made any necessary updates to the CLI.
- [x] I have made any necessary updates to the frontend.

## Description

This PR simplifies validation logic for the `Range`, `VPC`, `Subnet`, and `Host` schemas by leveraging Pydantic's `model_validator` that provides access to class attributes after each field has been individually validated. This allows for the removal of all the `if not field` checks.

Additionally, this PR deduplicates the validation logic by centralizing the validation functions in a `ValidationSchema` class that can be inherited  

Fixes: #107 
